### PR TITLE
Split up the AbstractTaskCommand and TaskCommand to add more flexibility

### DIFF
--- a/Command/AbstractTaskCommand.php
+++ b/Command/AbstractTaskCommand.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Jarobe\TaskRunnerBundle\Command;
+
+use Jarobe\TaskRunnerBundle\Entity\TaskEvent;
+use Jarobe\TaskRunnerBundle\Entity\TaskEventInterface;
+use Jarobe\TaskRunnerBundle\Manager\TaskEventManager;
+use Jarobe\TaskRunnerBundle\Manager\TaskManager;
+use Jarobe\TaskRunnerBundle\Model\TaskBuilder;
+use Jarobe\TaskRunnerBundle\TaskType\TaskTypeInterface;
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Validator\ConstraintViolationInterface;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+abstract class AbstractTaskCommand extends ContainerAwareCommand
+{
+    /** @var TaskEventManager */
+    protected $taskEventManager;
+
+    /** @var TaskManager */
+    protected $taskManager;
+
+    /** @var ValidatorInterface */
+    protected $validator;
+
+    public function initialize(InputInterface $input, OutputInterface $output)
+    {
+        parent::initialize($input, $output);
+        $container = $this->getContainer();
+        $this->taskEventManager = $container->get('jarobe.task_runner.task_event_manager');
+        $this->taskManager = $container->get('jarobe.task_runner.task_manager');
+        $this->validator = $container->get('validator');
+    }
+
+    /**
+     * @param TaskEventInterface $taskEvent
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     * @return TaskEvent
+     */
+    protected function process(TaskEventInterface $taskEvent, InputInterface $input, OutputInterface $output)
+    {
+        $this->preProcess($taskEvent, $input, $output);
+
+        $taskEvent = $this->taskManager->process($taskEvent);
+
+        $this->postProcess($taskEvent, $input, $output);
+
+        return $taskEvent;
+    }
+
+    /**
+     * Overwrite this function if you want to do something before we process the TaskEvent
+     * @param TaskEventInterface $taskEvent
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     */
+    protected function preProcess(TaskEventInterface $taskEvent, InputInterface $input, OutputInterface $output)
+    {
+    }
+
+    /**
+     * Overwrite this function if you want to do something after we process the TaskEvent
+     * @param TaskEventInterface $taskEvent
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     */
+    protected function postProcess(TaskEventInterface $taskEvent, InputInterface $input, OutputInterface $output)
+    {
+    }
+
+    /**
+     * @param TaskTypeInterface $task
+     * @return array
+     */
+    protected function validateTask(TaskTypeInterface $task)
+    {
+        $validationErrors = [];
+        $validationErrorList = $this->validator->validate($task);
+        /** @var ConstraintViolationInterface $error */
+        foreach ($validationErrorList as $error) {
+            $validationErrors[] = sprintf("%s: %s", $error->getPropertyPath(), $error->getMessage());
+        }
+        return $validationErrors;
+    }
+}

--- a/DependencyInjection/Compiler/DriverCompilerPass.php
+++ b/DependencyInjection/Compiler/DriverCompilerPass.php
@@ -3,7 +3,6 @@
 
 namespace Jarobe\TaskRunnerBundle\DependencyInjection\Compiler;
 
-
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;

--- a/DependencyInjection/Compiler/EntityManagerCompilerPass.php
+++ b/DependencyInjection/Compiler/EntityManagerCompilerPass.php
@@ -18,13 +18,15 @@ class EntityManagerCompilerPass implements CompilerPassInterface
     public function process(ContainerBuilder $container)
     {
         $entityManagerName = $container->getParameter('jarobe.task_runner.entity_manager');
-
-        $entityManagerReference = new Reference('doctrine.orm.entity_manager');
-        if ($entityManagerName !== null) {
-            $entityManagerReference = new Reference('doctrine.orm.entity_manager.'.$entityManagerName);
+        if ($entityManagerName === null) {
+            $entityManagerName = 'doctrine.orm.entity_manager';
         }
+        $entityManagerReference = new Reference($entityManagerName);
 
         $taskEventManagerDefinition = $container->getDefinition('jarobe.task_runner.task_event_manager');
         $taskEventManagerDefinition->replaceArgument(0, $entityManagerReference);
+
+        $taskEventRepository = $container->getDefinition('jarobe.task_runner.task_event_repository');
+        $taskEventRepository->setFactory([$entityManagerReference, 'getRepository']);
     }
 }

--- a/Entity/TaskEvent.php
+++ b/Entity/TaskEvent.php
@@ -4,12 +4,13 @@
 namespace Jarobe\TaskRunnerBundle\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
+use Jarobe\TaskRunnerBundle\TaskType\TaskTypeInterface;
 
 /**
  * @ORM\Table(name="task_event")
- * @ORM\Entity()
+ * @ORM\Entity(repositoryClass="Jarobe\TaskRunnerBundle\Repository\TaskEventRepository")
  */
-class TaskEvent
+class TaskEvent implements TaskEventInterface
 {
     /**
      * @var integer
@@ -207,5 +208,56 @@ class TaskEvent
         $this->targetTime = $targetTime;
 
         return $this;
+    }
+
+    /**
+     * @return TaskEventInterface
+     */
+    public function initiate()
+    {
+        $this->setInitiatedAt(new \DateTime());
+    }
+
+    /**
+     * @return TaskEventInterface
+     */
+    public function setAsCompleted()
+    {
+        $this->setCompletedAt(new \DateTime());
+    }
+
+    /**
+     * @param array $errors
+     */
+    public function setAsFailed(array $errors)
+    {
+        $this->setFailedAt(new \DateTime())
+            ->setErrors($errors)
+        ;
+    }
+
+    /**
+     * @param $name
+     * @param TaskTypeInterface $taskType
+     * @return TaskEventInterface
+     */
+    public function intialize($name, TaskTypeInterface $taskType)
+    {
+        $this->setTaskName($name)
+            ->setPayload($taskType->getPayload())
+            ->setTargetTime($taskType->getTargetTime())
+        ;
+    }
+
+    /** @return bool */
+    public function isComplete()
+    {
+        return $this->completedAt !== null;
+    }
+
+    /** @return bool */
+    public function isFailed()
+    {
+        return $this->failedAt !== null;
     }
 }

--- a/Entity/TaskEventInterface.php
+++ b/Entity/TaskEventInterface.php
@@ -1,0 +1,52 @@
+<?php
+
+
+namespace Jarobe\TaskRunnerBundle\Entity;
+
+use Jarobe\TaskRunnerBundle\TaskType\TaskTypeInterface;
+
+interface TaskEventInterface
+{
+    /**
+     * @return string
+     */
+    public function getTaskName();
+
+    /**
+     * @return array
+     */
+    public function getPayload();
+
+    /**
+     * @return \DateTime
+     */
+    public function getTargetTime();
+
+    /**
+     * @param $name
+     * @param TaskTypeInterface $taskType
+     * @return TaskEventInterface
+     */
+    public function intialize($name, TaskTypeInterface $taskType);
+
+    /**
+     * @return TaskEventInterface
+     */
+    public function initiate();
+
+    /**
+     * @return TaskEventInterface
+     */
+    public function setAsCompleted();
+
+    /**
+     * @param array $errors
+     */
+    public function setAsFailed(array $errors);
+
+    /** @return bool */
+    public function isComplete();
+
+    /** @return bool */
+    public function isFailed();
+}

--- a/Hydrator/Discovery.php
+++ b/Hydrator/Discovery.php
@@ -3,9 +3,7 @@
 
 namespace Jarobe\TaskRunnerBundle\Hydrator;
 
-use Doctrine\Common\Annotations\Reader;
 use Jarobe\TaskRunnerBundle\TaskType\TaskTypeInterface;
-use Jarobe\TaskRUnner\Annotation\TaskType;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
 
@@ -87,7 +85,7 @@ class Discovery implements DiscoveryInterface
             /** @var TaskTypeInterface $class */
             $class = $this->namespace . '\\' . $file->getBasename('.php');
 
-            if (!$class instanceof TaskTypeInterface) {
+            if (!in_array(TaskTypeInterface::class, class_implements($class))) {
                 continue;
             }
 

--- a/Hydrator/Hydrator.php
+++ b/Hydrator/Hydrator.php
@@ -2,7 +2,7 @@
 
 namespace Jarobe\TaskRunnerBundle\Hydrator;
 
-use Jarobe\TaskRunnerBundle\Entity\TaskEvent;
+use Jarobe\TaskRunnerBundle\Entity\TaskEventInterface;
 use Jarobe\TaskRunnerBundle\Exception\TaskException;
 use Jarobe\TaskRunnerBundle\TaskType\TaskTypeInterface;
 
@@ -16,11 +16,11 @@ class Hydrator implements HydratorInterface
     }
 
     /**
-     * @param TaskEvent $taskEvent
+     * @param TaskEventInterface $taskEvent
      * @return TaskTypeInterface
      * @throws TaskException
      */
-    public function getTaskFromTaskEvent(TaskEvent $taskEvent)
+    public function getTaskFromTaskEvent(TaskEventInterface $taskEvent)
     {
         $className = $this->registry->getClassByName($taskEvent->getTaskName());
 

--- a/Hydrator/HydratorInterface.php
+++ b/Hydrator/HydratorInterface.php
@@ -3,15 +3,16 @@
 namespace Jarobe\TaskRunnerBundle\Hydrator;
 
 use Jarobe\TaskRunnerBundle\Entity\TaskEvent;
+use Jarobe\TaskRunnerBundle\Entity\TaskEventInterface;
 use Jarobe\TaskRunnerBundle\Exception\TaskException;
 use Jarobe\TaskRunnerBundle\TaskType\TaskTypeInterface;
 
 interface HydratorInterface
 {
     /**
-     * @param TaskEvent $taskEvent
+     * @param TaskEventInterface $taskEvent
      * @return TaskTypeInterface
      * @throws TaskException
      */
-    public function getTaskFromTaskEvent(TaskEvent $taskEvent);
+    public function getTaskFromTaskEvent(TaskEventInterface $taskEvent);
 }

--- a/Hydrator/Reflector.php
+++ b/Hydrator/Reflector.php
@@ -3,7 +3,6 @@
 
 namespace Jarobe\TaskRunnerBundle\Hydrator;
 
-
 use Jarobe\TaskRunnerBundle\TaskType\TaskTypeInterface;
 
 class Reflector
@@ -12,7 +11,7 @@ class Reflector
      * @param TaskTypeInterface $taskType
      * @return string
      */
-    public function getNameForClass(TaskTypeInterface $taskType)
+    public function getNameForClass($taskType)
     {
         return $taskType::getName();
     }

--- a/Manager/TaskManager.php
+++ b/Manager/TaskManager.php
@@ -3,6 +3,7 @@
 namespace Jarobe\TaskRunnerBundle\Manager;
 
 use Jarobe\TaskRunnerBundle\Entity\TaskEvent;
+use Jarobe\TaskRunnerBundle\Entity\TaskEventInterface;
 use Jarobe\TaskRunnerBundle\Hydrator\HydratorInterface;
 use Jarobe\TaskRunnerBundle\Processor\ProcessorInterface;
 
@@ -37,10 +38,10 @@ class TaskManager
     }
 
     /**
-     * @param TaskEvent $taskEvent
-     * @return TaskEvent
+     * @param TaskEventInterface $taskEvent
+     * @return TaskEventInterface
      */
-    public function process(TaskEvent $taskEvent)
+    public function process(TaskEventInterface $taskEvent)
     {
         $this->taskEventManager->initiateTaskEvent($taskEvent);
 

--- a/Provider/TaskEventProvider.php
+++ b/Provider/TaskEventProvider.php
@@ -1,0 +1,61 @@
+<?php
+
+
+namespace Jarobe\TaskRunnerBundle\Provider;
+
+use Jarobe\TaskRunnerBundle\Entity\TaskEvent;
+use Jarobe\TaskRunnerBundle\Repository\TaskEventRepository;
+
+class TaskEventProvider implements TaskEventProviderInterface
+{
+    private $repository;
+
+    public function __construct(TaskEventRepository $repository)
+    {
+        $this->repository = $repository;
+    }
+
+    /**
+     * @param \DateTime $dateTime
+     * @param $typeName
+     * @return TaskEvent[]
+     */
+    public function getCompletedTaskEvents(\DateTime $dateTime, $typeName)
+    {
+        return $this->repository->getCompletedTaskEvents($dateTime, $typeName);
+    }
+
+    /**
+     * @param \DateTime $dateTime
+     * @param $typeName
+     * @return TaskEvent[]
+     */
+    public function getPendingTaskEvents(\DateTime $dateTime, $typeName)
+    {
+        return $this->repository->getPendingTaskEvents($dateTime, $typeName);
+    }
+
+    /**
+     * @param \DateTime $dateTime
+     * @param $typeName
+     * @return TaskEvent[]
+     */
+    public function getScheduledTaskEvents(\DateTime $dateTime, $typeName)
+    {
+        return $this->repository->getScheduledTaskEvents($dateTime, $typeName);
+    }
+
+    /**
+     * @param \DateTime $dateTime
+     * @param $typeName
+     * @return TaskEvent|null
+     */
+    public function getNextScheduledTaskEvent(\DateTime $dateTime, $typeName)
+    {
+        $scheduled = $this->getScheduledTaskEvents($dateTime, $typeName);
+        if (count($scheduled)) {
+            return $scheduled[0];
+        }
+        return null;
+    }
+}

--- a/Provider/TaskEventProviderInterface.php
+++ b/Provider/TaskEventProviderInterface.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jarobe\TaskRunnerBundle\Provider;
+
+use Jarobe\TaskRunnerBundle\Entity\TaskEvent;
+
+interface TaskEventProviderInterface
+{
+    /**
+     * @param \DateTime $dateTime
+     * @param $typeName
+     * @return TaskEvent[]
+     */
+    public function getCompletedTaskEvents(\DateTime $dateTime, $typeName);
+
+    /**
+     * @param \DateTime $dateTime
+     * @param $typeName
+     * @return TaskEvent[]
+     */
+    public function getPendingTaskEvents(\DateTime $dateTime, $typeName);
+
+    /**
+     * @param \DateTime $dateTIme
+     * @param $typeName
+     * @return TaskEvent[]
+     */
+    public function getScheduledTaskEvents(\DateTime $dateTIme, $typeName);
+
+    /**
+     * @param \DateTime $dateTIme
+     * @param $typeName
+     * @return TaskEvent|null
+     */
+    public function getNextScheduledTaskEvent(\DateTime $dateTIme, $typeName);
+}

--- a/Repository/TaskEventRepository.php
+++ b/Repository/TaskEventRepository.php
@@ -1,0 +1,94 @@
+<?php
+
+
+namespace Jarobe\TaskRunnerBundle\Repository;
+
+use Doctrine\ORM\EntityRepository;
+use Jarobe\TaskRunnerBundle\Entity\TaskEvent;
+
+class TaskEventRepository extends EntityRepository
+{
+    /**
+     * @param \DateTime $dateTime
+     * @param $taskName
+     * @return TaskEvent[]
+     */
+    public function getCompletedTaskEvents(\DateTime $dateTime, $taskName)
+    {
+        $qb = $this->createQueryBuilder('te');
+        $qb->andWhere('te.taskName = :taskName')
+            ->andWhere('te.targetTime = :targetTime')
+            ->andWhere('te.completedAt IS NOT NULL')
+        ;
+        $qb->setParameter('taskName', $taskName)
+            ->setParameter('targetTime', $dateTime)
+        ;
+
+        $query = $qb->getQuery();
+        return $query->getResult();
+    }
+
+    /**
+     * @param \DateTime $dateTime
+     * @param $taskName
+     * @return TaskEvent[]
+     */
+    public function getFailedTaskEvents(\DateTime $dateTime, $taskName)
+    {
+        $qb = $this->createQueryBuilder('te');
+        $qb->andWhere('te.taskName = :taskName')
+            ->andWhere('te.targetTime = :targetTime')
+            ->andWhere('te.failedAt IS NOT NULL')
+        ;
+        $qb->setParameter('taskName', $taskName)
+            ->setParameter('targetTime', $dateTime)
+        ;
+
+        $query = $qb->getQuery();
+        return $query->getResult();
+    }
+
+    /**
+     * @param \DateTime $dateTime
+     * @param $taskName
+     * @return TaskEvent[]
+     */
+    public function getPendingTaskEvents(\DateTime $dateTime, $taskName)
+    {
+        $qb = $this->createQueryBuilder('te');
+        $qb->andWhere('te.taskName = :taskName')
+            ->andWhere('te.targetTime = :targetTime')
+            ->andWhere('te.completed IS NULL')
+            ->andWhere('te.failedAt IS NULL')
+            ->andWhere('te.initiatedAt IS NOT NULL')
+        ;
+        $qb->setParameter('taskName', $taskName)
+            ->setParameter('targetTime', $dateTime)
+        ;
+
+        $query = $qb->getQuery();
+        return $query->getResult();
+    }
+
+    /**
+     * @param \DateTime $dateTime
+     * @param $taskName
+     * @return TaskEvent[]
+     */
+    public function getScheduledTaskEvents(\DateTime $dateTime, $taskName)
+    {
+        $qb = $this->createQueryBuilder('te');
+        $qb->andWhere('te.taskName = :taskName')
+            ->andWhere('te.targetTime = :targetTime')
+            ->andWhere('te.initiatedAt IS NULL')
+        ;
+        $qb->setParameter('taskName', $taskName)
+            ->setParameter('targetTime', $dateTime)
+        ;
+
+        $qb->addOrderBy('te.id', 'ASC');
+
+        $query = $qb->getQuery();
+        return $query->getResult();
+    }
+}

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -26,7 +26,7 @@ services:
         arguments:
           - '%jarobe.task_runner.types.namespace%'
           - '%jarobe.task_runner.types.directory%'
-          - 'kernel.root_dir%'
+          - '%kernel.root_dir%'
           - '@jarobe.task_runner.reflector'
         public: false
 
@@ -36,10 +36,23 @@ services:
           - '@jarobe.task_runner.discovery'
         public: false
 
+    jarobe.task_runner.task_event_repository:
+        class: Jarobe\TaskRunnerBundle\Repository\TaskEventRepository
+        factory: ''
+        arguments:
+            - 'Jarobe\TaskRunnerBundle\Entity\TaskEvent'
+        public: false
+
+    jarobe.task_runner.task_event_provider:
+        class: Jarobe\TaskRunnerBundle\Provider\TaskEventProvider
+        arguments:
+            - '@jarobe.task_runner.task_event_repository'
+        public: true
+
     jarobe.task_runner.task_event_manager:
         class: Jarobe\TaskRunnerBundle\Manager\TaskEventManager
         arguments:
-            - '@doctrine.orm.report_entity_manager'
+            - ''
             - '@jarobe.task_runner.reflector'
         public: true
 

--- a/Tests/Manager/TaskEventManagerTest.php
+++ b/Tests/Manager/TaskEventManagerTest.php
@@ -44,7 +44,8 @@ class TaskEventManagerTest extends \PHPUnit_Framework_TestCase
 
         $this->reflector->getNameForClass($taskType)->willReturn($taskTypeName);
 
-        $taskEvent = $this->taskEventManager->createTaskEvent($taskType->reveal());
+        $taskEvent = new TaskEvent();
+        $taskEvent = $this->taskEventManager->createTaskEvent($taskEvent, $taskType->reveal());
 
         $this->assertEquals($taskTypeName, $taskEvent->getTaskName());
         $this->assertEquals($targetTime, $taskEvent->getTargetTime());


### PR DESCRIPTION
This gives the user more flexibility about how they want to build a a command. For instance, If they want to create a Command that schedules tasks without running it right away, they can.