### PR TITLE
Fix status code of executed command

### DIFF
--- a/Command/TaskCommand.php
+++ b/Command/TaskCommand.php
@@ -41,7 +41,7 @@ abstract class TaskCommand extends AbstractTaskCommand
         $taskEvent = new TaskEvent();
         $taskEvent = $this->taskEventManager->createTaskEvent($taskEvent, $taskBuilder->getTask());
         $taskEvent = $this->process($taskEvent, $input, $output);
-        return $taskEvent->isComplete() ? 1 : 0;
+        return $taskEvent->isComplete() ? 0 : 1;
     }
 
     /**


### PR DESCRIPTION
The returned value of `Symfony\Component\Console\Command::execute` is expected to be either void or a status code

Command successfully completed are expected to return a status code of 0.
